### PR TITLE
Update winston-papertrail.js

### DIFF
--- a/winston-papertrail.js
+++ b/winston-papertrail.js
@@ -1,1 +1,1 @@
-Winston_Papertrail = Npm.require("winston-papertrail").Papertrail;
+Winston_Papertrail = WinstonPapertrail = Npm.require("winston-papertrail").Papertrail;


### PR DESCRIPTION
As per ESLint conventions, CamelCase notation must be used.
